### PR TITLE
Fix bug : 'ionic g page pages/pagename' failure

### DIFF
--- a/topicApp/src/app/app-routing.module.ts
+++ b/topicApp/src/app/app-routing.module.ts
@@ -1,0 +1,22 @@
+import { NgModule } from '@angular/core';
+import { PreloadAllModules, RouterModule, Routes } from '@angular/router';
+
+const routes: Routes = [
+  {
+    path: '',
+    redirectTo: 'home',
+    pathMatch: 'full'
+  },
+  {
+    path: 'login',
+    loadChildren: () => import('./pages/login/login.module').then( m => m.LoginPageModule)
+  },
+];
+
+@NgModule({
+  imports: [
+    RouterModule.forRoot(routes, { preloadingStrategy: PreloadAllModules })
+  ],
+  exports: [RouterModule]
+})
+export class AppRoutingModule { }


### PR DESCRIPTION
Could not find an NgModule. Use the skip-import option to skip importing in NgModule. [ERROR] Could not generate page.

The problem was that 'app-routing.module.ts' was missing. The ionic page generation command now works.