### PR TITLE
Remplacement navigateForward -> navigateBack

### DIFF
--- a/topicApp/src/app/pages/signup/signup.page.ts
+++ b/topicApp/src/app/pages/signup/signup.page.ts
@@ -124,7 +124,7 @@ export class SignupPage implements OnInit {
   }
 
   goLogin() {
-    this.navigationControl.navigateForward('login');
+    this.navigationControl.navigateBack('login');
   }
 }
 


### PR DESCRIPTION
Pour que l'animation de changement de page entre singup et login soit plus cohérente, j'ai remplacé l'appel par un backward. De cette manière, depuis le login on avance d'une page vers le singup, et de ce dernier on recule d'une page pour revenir en arrière.

Important -> Je pense que ça permet aussi de dépiler la pile Android et d'éviter d'avoir plusieurs pages de logins dans la stack.